### PR TITLE
Attach to `buffer` and `res` schemes

### DIFF
--- a/LSP-lemminx.sublime-settings
+++ b/LSP-lemminx.sublime-settings
@@ -31,7 +31,11 @@
 		// "-Dhttps.proxyPort=<proxy_port>",
 	],
 
+	// base scope selectors to attach to
 	"selector": "text.plist | text.xml",
+
+	// type of buffers to attach to
+	"schemes": ["file", "buffer", "res"],
 
 	"settings": {
 		"xml.logs.client": true,


### PR DESCRIPTION
This language server seems to work fine in file-less views.