### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -359,9 +359,9 @@ class LemminxPlugin(AbstractPlugin):
         configuration.settings.set("xml.server.workDir", cls.server_path())
         configuration.settings.set("xml.telemetry.enabled", False)
         # apply settings to initialization options
-        configuration.init_options.set("settings.xml", configuration.settings.get("xml"))
+        configuration.initialization_options.set("settings.xml", configuration.settings.get("xml"))
         # apply hard coded initialization options
-        configuration.init_options.set("extendedClientCapabilities", {
+        configuration.initialization_options.set("extendedClientCapabilities", {
             "actionableNotificationSupport": False,
             "openSettingsCommandSupport": False,
             "bindingWizardSupport": False,


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
