### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,15 +1,5 @@
 from __future__ import annotations
 
-from io import BytesIO
-from LSP.plugin import AbstractPlugin
-from LSP.plugin import ClientConfig
-from LSP.plugin import filename_to_uri
-from LSP.plugin import register_plugin
-from LSP.plugin import unregister_plugin
-from LSP.plugin import WorkspaceFolder
-from urllib.request import Request as HttpRequest
-from urllib.request import urlopen
-from urllib.request import urlretrieve
 import contextlib
 import json
 import os
@@ -17,6 +7,17 @@ import re
 import sublime
 import time
 import zipfile
+from io import BytesIO
+from urllib.request import Request as HttpRequest, urlopen, urlretrieve
+
+from LSP.plugin import (
+    AbstractPlugin,
+    ClientConfig,
+    WorkspaceFolder,
+    filename_to_uri,
+    register_plugin,
+    unregister_plugin,
+)
 
 __all__ = ["LemminxPlugin", "plugin_loaded", "plugin_unloaded"]
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,4 +1,15 @@
 from __future__ import annotations
+
+from io import BytesIO
+from LSP.plugin import AbstractPlugin
+from LSP.plugin import ClientConfig
+from LSP.plugin import filename_to_uri
+from LSP.plugin import register_plugin
+from LSP.plugin import unregister_plugin
+from LSP.plugin import WorkspaceFolder
+from urllib.request import Request as HttpRequest
+from urllib.request import urlopen
+from urllib.request import urlretrieve
 import contextlib
 import json
 import os
@@ -6,20 +17,6 @@ import re
 import sublime
 import time
 import zipfile
-
-from http.client import HTTPException
-from io import BytesIO
-from urllib.request import urlretrieve, urlopen, Request as HttpRequest
-
-from LSP.plugin import (
-    AbstractPlugin,
-    ClientConfig,
-    DottedDict,
-    WorkspaceFolder,
-    register_plugin,
-    filename_to_uri,
-    unregister_plugin,
-)
 
 __all__ = ["LemminxPlugin", "plugin_loaded", "plugin_unloaded"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
-[tool.black]
-line-length = 100
-target-version = ['py38']
+
+[tool.pyright]
+pythonVersion = "3.8"
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
-
 [tool.pyright]
 pythonVersion = "3.8"
 
 [tool.ruff]
-line-length = 120
+line-length = 100
 target-version = "py38"
 
 [tool.ruff.lint]
@@ -12,9 +11,8 @@ preview = true
 select = ["F401", "I"]
 
 [tool.ruff.lint.isort]
-case-sensitive = false
-force-single-line = true
-from-first = true
-no-sections = true
+case-sensitive = true
+combine-as-imports = true
+extra-standard-library = ["sublime", "sublime_lib", "sublime_types"]
 order-by-type = false
 required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)