### PR TITLE
Update download_url and server_binary for versioning

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -207,7 +207,7 @@ def version_tuple(value: str) -> tuple[str, str, str]:
         return (999, 0, 0)
     try:
         return tuple(map(int, (value.split("."))))
-    except Exception as e:
+    except Exception:
         return (0, 0, 0)
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -165,7 +165,7 @@ class BinaryServerHandler(BaseServerHandler):
     @classmethod
     def download_url(cls) -> str:
         release_assets = {
-            "linux-x64": "lemminx-linux.zip",
+            "linux-x64": "lemminx-linux.zip" if version_tuple(cls.server_version) < version_tuple('0.29.1') else "lemminx-linux-x86_64.zip",
             "osx-arm64": "lemminx-osx-aarch_64.zip",
             "osx-x64": "lemminx-osx-x86_64.zip",
             "windows-x64": "lemminx-win32.zip",
@@ -183,7 +183,7 @@ class BinaryServerHandler(BaseServerHandler):
     @classmethod
     def server_binary(cls) -> str:
         names = {
-            "linux-x64": "lemminx-linux",
+            "linux-x64": "lemminx-linux" if version_tuple(cls.server_version) < version_tuple('0.29.1') else "lemminx-linux-x86_64",
             "osx-arm64": "lemminx-osx-aarch_64",
             "osx-x64": "lemminx-osx-x86_64",
             "windows-x64": "lemminx-win32.exe",
@@ -199,6 +199,16 @@ class BinaryServerHandler(BaseServerHandler):
         arch = sublime.arch()
         os = sublime.platform()
         return arch == "x64" or os == "osx" and arch == "arm64"
+
+
+def version_tuple(value: str) -> tuple[str, str, str]:
+    ''' Naive function to compare versions. '''
+    if value == 'latest':
+        return (999, 0, 0)
+    try:
+        return tuple(map(int, (value.split("."))))
+    except Exception as e:
+        return (0, 0, 0)
 
 
 class JavaServerHandler(BaseServerHandler):


### PR DESCRIPTION
fixes #24 

The Linux asset name changed from lemminx-linux.zip to lemminx-linux-x86_64.zip 
in this pre-release https://github.com/redhat-developer/vscode-xml/releases/tag/latest

But the `latest` release was created ~last week
https://github.com/redhat-developer/vscode-xml/releases

so in this PR for all version less then 0.29.1 we will use the old asset name.


# Testing

I tested the PR with:
```
// Settings in here override those in "LSP-lemminx/LSP-lemminx.sublime-settings"

{
	// "server_version": "0.29.0" // works, lemminx-linux.zip is fetched
        // "server_version": "0.29.1" // works, lemminx-linux-x86_64.zip is fetched
        // "server_version": "latest" // works, lemminx-linux-x86_64.zip is fetched
        // "server_version": "wrong version" // same behavior as before, we will see an error dialog
}

```


